### PR TITLE
Remove broken FinOps Benchmark nav entry

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -41,12 +41,6 @@
         ]
       },
       {
-        "group": "FinOps Benchmark",
-        "pages": [
-          "finops-benchmark/overview"
-        ]
-      },
-      {
         "group": "Workflow Management",
         "pages": [
           "workflow-management/workflow-templates",


### PR DESCRIPTION
Removes the "FinOps Benchmark" nav group from `docs.json`. It pointed to `finops-benchmark/overview`, a page that was never merged to main, so https://docs.openops.com/finops-benchmark/overview has served a 404 since April 2026.

The entry slipped into main via #341, which was extracted from the stacked `ops-3865` branch and carried over that branch's nav additions without the benchmark page itself. Since the benchmark isn't announced to users yet, the nav group is removed entirely; the page content still lives on `ops-3865` and can be revived when the benchmark launches.

## Testing

Validated `docs.json` still parses as JSON after the removal; the block was removed exactly once, no other nav entries touched.

Fixes OPS-4781.